### PR TITLE
fix: make email optional and add form input notice

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -20,11 +20,12 @@
     <div class="mt-4">
       <h3 class="text-2xl font-medium text-gray-900">Credit</h3>
       <p class="text-gray-500 mt-2">
-        Trang web có sử dụng nguồn dữ liệu ban đầu từ
-        <a class="text-primary underline" href="https://voz.vn/f/lap-trinh-cntt.91/" target="_blank">Voz</a> và
+        Dữ liệu ban đầu của trang web được đóng góp bởi các bạn trong
         <a class="text-primary underline" href="https://www.facebook.com/groups/1177470863076165" target="_blank"
           >Viet Tech</a
-        >.
+        >,
+        <a class="text-primary underline" href="https://www.webuild.community" target="_blank">WeBuild</a>
+        và một số cộng đồng IT Việt Nam khác.
       </p>
     </div>
 

--- a/pages/salaries/submit/form-input.vue
+++ b/pages/salaries/submit/form-input.vue
@@ -5,6 +5,20 @@
         <div>
           <div>
             <h3 class="text-2xl font-medium text-gray-900">Nhập lương của bạn</h3>
+            <ul class="text-sm text-gray-500 mt-2">
+              <li>
+                - Vui lòng nhập lương <i>gross</i>, đơn vị là <i>triệu VND</i> (nếu lương thực là
+                <b class="font-semibold">50.000.000</b> -> nhập <b class="font-semibold">50</b>)
+              </li>
+              <li>
+                - Nếu lương thưởng của bạn cao hơn với mặt bằng chung nhiều, vui lòng để lại email để bọn mình có thể
+                xác nhận dữ liệu, hoặc thêm ghi chú cụ thể ở mục
+                <b class="font-semibold">Ghi chú thêm</b>
+              </li>
+              <li>
+                - Nếu bạn nhập dữ liệu nhiều lần, vui lòng để lại lý do ở mục <b class="font-semibold">Ghi chú thêm</b>
+              </li>
+            </ul>
           </div>
 
           <div class="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
@@ -33,7 +47,6 @@
                 type="number"
                 no-appearance
                 currency-unit="triệu VND"
-                placeholder="Chú ý đơn vị, tránh thừa số 0"
                 :invalid="!!v$.monthlySalary.$error"
               />
             </div>
@@ -74,6 +87,7 @@
               <CoreTextField
                 v-model="yearOfReceivedCompensation"
                 label="Năm nhận hợp đồng lương"
+                type="number"
                 :invalid="!!v$.yearOfReceivedCompensation.$error"
               />
             </div>
@@ -83,8 +97,8 @@
                 v-model="email"
                 label="Email"
                 type="email"
-                placeholder="Bọn mình có thể liên lạc để xác nhận dữ liệu nhập"
-                :invalid="!!v$.email.$error"
+                placeholder="Dùng để xác thực dữ liệu nhập"
+                optional
               />
             </div>
 
@@ -187,7 +201,6 @@ const rules = {
   yearOfExperience: { required },
   yearOfReceivedCompensation: { required },
   monthlySalary: { required },
-  email: { required },
   annualExpectedBonus: { required, minLength: minLength(1) },
 };
 const v$ = useVuelidate(rules, {
@@ -198,7 +211,6 @@ const v$ = useVuelidate(rules, {
   yearOfReceivedCompensation,
   monthlySalary,
   annualExpectedBonus,
-  email,
 });
 
 async function submitSalary() {


### PR DESCRIPTION
@tuna-date @white-ws 
Changes:
- Add form input notice (regarding email collection and some common error cases)
- Make email optional again (for 2 reasons: it is hard to verify the impact without analytic metrics, eg the number of registrations/drop off rate, before/after; anyone who does not want to fill in his real email (eg a bad actor), he would fill a dummy one, though arguably we can use email as a criteria to judge the data quality).

<img width="1503" alt="Screenshot 2023-03-12 at 20 54 58" src="https://user-images.githubusercontent.com/14136939/224542928-3d1083b2-352b-4f53-898f-b41eaf03080c.png">
